### PR TITLE
Limit message parse try/catch to parse command only

### DIFF
--- a/src/Dispatch.ts
+++ b/src/Dispatch.ts
@@ -106,26 +106,26 @@ export default class Dispatch {
             payload,
             latencyMs,
           } = JSON.parse(e.data);
-          this._latency = latencyMs;
-
-          // Handle Koji scoped messages
-          if (eventName === DISPATCH_EVENT.CONNECTED) {
-            this._clientId = payload.clientId;
-            this._shardName = payload.shardName;
-          }
-          if (eventName === DISPATCH_EVENT.CONNECTED_CLIENTS_CHANGED) {
-            this._connectedClients = payload.connectedClients;
-          }
-
-          // Handle custom messages
-          this.eventHandlers.forEach((handler) => {
-            if (eventName === handler.eventName) {
-              handler.callback(payload);
-            }
-          });
         } catch (err) {
           console.log('[Koji Dispatch] error parsing message');
         }
+        this._latency = latencyMs;
+
+        // Handle Koji scoped messages
+        if (eventName === DISPATCH_EVENT.CONNECTED) {
+          this._clientId = payload.clientId;
+          this._shardName = payload.shardName;
+        }
+        if (eventName === DISPATCH_EVENT.CONNECTED_CLIENTS_CHANGED) {
+          this._connectedClients = payload.connectedClients;
+        }
+
+        // Handle custom messages
+        this.eventHandlers.forEach((handler) => {
+          if (eventName === handler.eventName) {
+            handler.callback(payload);
+          }
+        });
       },
       onreconnect: (e) => {
         console.log('[Koji Dispatch] reconnected');


### PR DESCRIPTION
Move try/catch statement to make it easier to debug issues in custom message handlers.

As far as I can see the only reason for this try/catch statement is to error handle the JSON.parse, if it's needed for any of the rest let me know and I can adjust the change.